### PR TITLE
enhance API layer with Dio client and error handling

### DIFF
--- a/lib/core/network/api_error.dart
+++ b/lib/core/network/api_error.dart
@@ -1,0 +1,10 @@
+class ApiError {
+  final String message;
+  final int? statusCode;
+
+  ApiError(this.message, this.statusCode);
+  @override
+  String toString() {
+    return "Error is : $message \n  Status Code is $statusCode";
+  }
+}

--- a/lib/core/network/api_exceptions.dart
+++ b/lib/core/network/api_exceptions.dart
@@ -1,0 +1,57 @@
+import 'package:dio/dio.dart';
+
+class ApiException implements Exception {
+  final String message;
+  final int? statusCode;
+
+  ApiException(this.message, [this.statusCode]);
+
+  @override
+  String toString() => 'ApiException ($statusCode): $message';
+
+  /// Factory method to handle Dio errors gracefully
+  factory ApiException.fromDioError(DioException error) {
+    switch (error.type) {
+      case DioExceptionType.connectionTimeout:
+        return ApiException("Connection timeout. Please try again later.");
+      case DioExceptionType.sendTimeout:
+        return ApiException("Send timeout. Please try again later.");
+      case DioExceptionType.receiveTimeout:
+        return ApiException("Receive timeout. Please try again later.");
+      case DioExceptionType.badCertificate:
+        return ApiException("Invalid SSL certificate from the server.");
+      case DioExceptionType.badResponse:
+        return ApiException._handleBadResponse(error.response);
+      case DioExceptionType.cancel:
+        return ApiException("Request was cancelled by the user.");
+      case DioExceptionType.connectionError:
+        return ApiException("Failed to connect to the server. Check your internet connection.");
+      case DioExceptionType.unknown:
+        return ApiException("An unexpected error occurred. Please try again.");
+      
+    }
+  }
+
+  /// Handle different HTTP response codes
+  static ApiException _handleBadResponse(Response? response) {
+    final statusCode = response?.statusCode;
+    final message = response?.data is Map && response?.data['message'] != null
+        ? response?.data['message'].toString()
+        : "Something went wrong while processing your request.";
+
+    switch (statusCode) {
+      case 400:
+        return ApiException("Bad Request: $message", statusCode);
+      case 401:
+        return ApiException("Unauthorized: Please log in again.", statusCode);
+      case 403:
+        return ApiException("Forbidden: You don’t have permission to access this resource.", statusCode);
+      case 404:
+        return ApiException("Not Found: The requested resource could not be found.", statusCode);
+      case 500:
+        return ApiException("Internal Server Error. Please try again later.", statusCode);
+      default:
+        return ApiException(message!, statusCode);
+    }
+  }
+}

--- a/lib/core/network/api_serves.dart
+++ b/lib/core/network/api_serves.dart
@@ -1,0 +1,77 @@
+import 'package:dio/dio.dart';
+import 'package:hungry/core/network/api_exceptions.dart';
+import 'package:hungry/core/network/dio_client.dart';
+
+class ApiService {
+  final DioClient _dioClient = DioClient();
+
+  /// GET request
+  Future<dynamic> getRequest(
+    String endpoint
+     
+  ) async {
+    try {
+      final response = await _dioClient.dio.get(
+        endpoint,
+         
+      );
+      return response.data;
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  /// POST request
+  Future<dynamic> postRequest(
+    String endpoint, {
+    dynamic data,
+     
+  }) async {
+    try {
+      final response = await _dioClient.dio.post(
+        endpoint,
+        data: data,
+         
+      );
+      return response.data;
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  /// PUT request
+  Future<dynamic> putRequest(
+    String endpoint, {
+    dynamic data,
+     
+  }) async {
+    try {
+      final response = await _dioClient.dio.put(
+        endpoint,
+        data: data,
+         
+      );
+      return response.data;
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+
+  /// DELETE request
+  Future<dynamic> deleteRequest(
+    String endpoint, {
+    dynamic data,
+     
+  }) async {
+    try {
+      final response = await _dioClient.dio.delete(
+        endpoint,
+        data: data,
+         
+      );
+      return response.data;
+    } on DioException catch (e) {
+      throw ApiException.fromDioError(e);
+    }
+  }
+}

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -1,0 +1,25 @@
+import 'package:dio/dio.dart';
+import 'package:hungry/core/utils/pref_helper.dart';
+
+class DioClient {
+  final Dio _dio = Dio(
+    BaseOptions(
+      baseUrl: "https://sonic-zdi0.onrender.com/apiF",
+      headers: {"Content-Type": 'application/json'},
+    ),
+  );
+  DioClient() {
+    _dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) async {
+          final token = await PrefHelper.getToken();
+          if (token != null && token.isNotEmpty) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
+          return handler.next(options);
+        },
+      ),
+    );
+  }
+  Dio get dio => _dio;
+}

--- a/lib/core/utils/pref_helper.dart
+++ b/lib/core/utils/pref_helper.dart
@@ -1,0 +1,25 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class PrefHelper {
+  static const String _tokenKey = 'auth_token';
+
+  static Future<void> saveToken(String token) async {
+    final prefs = await SharedPreferences.getInstance();
+
+    await prefs.setString(_tokenKey, token);
+  }
+
+  static Future<String?> getToken() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    return prefs.getString(_tokenKey);
+  }
+
+  static Future<String?> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+
+    prefs.clear();
+
+    return null;
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.8"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "7586e476d70caecaf1686d21eee7247ea43ef5c345eab9e0cc3583ff13378d78"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -65,6 +81,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.2"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.4"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -96,6 +128,11 @@ packages:
     version: "2.2.1"
   flutter_test:
     dependency: "direct dev"
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.0"
@@ -179,6 +216,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -195,6 +240,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   petitparser:
     dependency: transitive
     description:
@@ -203,6 +272,78 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.8"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.3"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      sha256: bd14436108211b0d4ee5038689a56d4ae3620fd72fd6036e113bf1345bc74d9e
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.13"
+  shared_preferences_foundation:
+    dependency: transitive
+    description:
+      name: shared_preferences_foundation
+      sha256: "6a52cfcdaeac77cad8c97b539ff688ccfc458c007b4db12be584fbe5c0e49e03"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      sha256: "580abfd40f415611503cae30adf626e6656dfb2f0cee8f465ece7b6defb40f2f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      sha256: c49bd060261c9a3f0ff445892695d6212ff603ef3115edbb448509d407600019
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      sha256: "94ef0f72b2d71bc3e700e025db3710911bd51a71cefb65cc609dd0d9a982e3c1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -312,6 +453,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   flutter_screenutil: ^5.9.3
   flutter_svg: ^2.2.1
   gap: ^3.0.1
+  dio: ^5.9.0
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Added new `dio_client.dart` for centralized HTTP client configuration
- Introduced `api_error.dart` for detailed API error modeling
- Updated `api_exceptions.dart` and `api_serves.dart` for improved error handling and response management
- Added `pref_helper.dart` for shared preferences utilities
- Updated `pubspec.yaml` and `pubspec.lock` to include Dio and related dependencies
- Modified macOS plugin registrant for dependency registration